### PR TITLE
mark .deb as conflicting with Ubuntu arc pkg

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -37,6 +37,8 @@ nfpms:
     formats:
       - deb
     bindir: /usr/bin
+    conflicts:
+      - arc
 
 brews:
   - tap:


### PR DESCRIPTION
Now that Arc has a new Debian package name, `hubci-arc`, let's mark the
package that ships with Ubuntu as a conflict.